### PR TITLE
Adds support for HTML filtering and Hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 *.gem
+
+tmp/spam_triggers.json

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Spambox
-A simple gem that uses formbox.es to give a spam score based on spammy keywords for any ActiveRecord- or String object.
+A simple gem that uses formbox.es to give a spam score (0-100) based on spammy keywords for any Array, Hash, ActiveRecord- or String object.
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem "spambox"
+    gem "spambox", "~> 0.2"
 
 And then execute:
 
@@ -13,18 +13,29 @@ And then execute:
 
 ## Usage
 
-Spambox accepts any `String` or `ActiveRecord` object. It basically counts the occurences of suspicious keywords
-and returns the percentage of words that it doesn't trust.
+Spambox accepts any `Array`, `Hash`, `ActiveRecord` or `String` object. It basically counts the occurences of suspicious keywords and returns the percentage of words that it doesn't trust.
 
-It's up to you to determine a threshold to treat an object as spam. 
+It's up to you to determine a threshold to treat an object as spam.
 
 Example usage:
 
 ```ruby
 Spambox.new("Some pretty trustworthy string.").spam_score
-# This will return 0 (%) since none of these words occur in Formbox.es blacklist.
+# This will return 0 since none of these words occur in Formbox.es blacklist.
 
-Spambox.new("Hi, do you want cheap drugs?").spam_score
-# This will return 33 (%) since two of the six words are treated as unsafe.
+Spambox.new("Hi, do you want cheap xanax?").spam_score
+# This will return 33 since two of the six words are treated as unsafe.
 # You can probably guess which ones.
+```
+
+## Configuration
+
+By default, Spambox will return a `spam_score` of `100` when the provided object contains any HTML code.
+
+```ruby
+Spambox.new("Some pretty trustworthy string, but it does contain html <a href='example.com'>bar</a>.").spam_score
+# This will return 100 because it contains HTML.
+
+Spambox.new("Hi, do you want <a href='example.com'>cheap xanax?</a>", { allow_html: true }).spam_score
+# This will return 33 since two of the six words are treated as unsafe, but the HTMl is accepted.
 ```

--- a/spambox.gemspec
+++ b/spambox.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = 'spambox'
-  gem.version       = '0.1'
+  gem.version       = '0.2'
   gem.date          = '2015-12-04'
   gem.authors       = ["Joshua Jansen"]
   gem.email         = ["joshuajansen88@gmail.com"]
@@ -11,4 +11,5 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/joshuajansen/spambox"
   gem.files         = ["lib/spambox.rb"]
   gem.license       = 'MIT'
+  gem.add_runtime_dependency "sanitize", "~> 4.0"
 end

--- a/test/test_spam_filter.rb
+++ b/test/test_spam_filter.rb
@@ -7,6 +7,18 @@ class TestSpambox < Minitest::Test
     assert_equal Spambox.new("pharmacy").spam_score, 100
   end
 
+  def test_string_with_html_is_100
+    assert_equal Spambox.new("<a href='#foo'>").spam_score, 100
+  end
+
+  def test_safe_string_with_html_allowed_is_0
+    assert_equal Spambox.new("<a href='#foo'>", { allow_html: true }).spam_score, 0
+  end
+
+  def test_unsafe_string_with_html_allowed_is_100
+    assert_equal Spambox.new("<a href='#foo'>pharmacy</a>", { allow_html: true }).spam_score, 100
+  end
+
   def test_half_spam_words_is_50
     assert_equal Spambox.new("pharmacy banana").spam_score, 50
   end


### PR DESCRIPTION
Adds `allow_html` option to the initializer. When disabled (which it is by default), `spam_score` will return `100` if the provided content contains any HTML tags.

Spambox now also accepts an `Array` or `Hash`. For both it will (flatten down and) join the values into one big string that it will use to scan for unsafe keywords.