### PR TITLE
Allow newlines from textareas and refactors hash flattening

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,32 @@
+Style/DotPosition:
+  EnforcedStyle: trailing
+Style/IndentationWidth:
+  Width: 2
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+Style/TrailingBlankLines:
+  EnforcedStyle: final_newline
+  SupportedStyles:
+    - final_newline
+    - final_blank_line
+Metrics/LineLength:
+  Max: 110
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+Metrics/MethodLength:
+  CountComments: false
+  Max: 40
+Metrics/AbcSize:
+  Max: 25
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: true

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple gem that uses formbox.es to give a spam score (0-100) based on spammy k
 
 Add this line to your application's Gemfile:
 
-    gem "spambox", "~> 0.2"
+    gem "spambox", "~> 0.3"
 
 And then execute:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
-require 'rake/testtask'
+require "rake/testtask"
 
 Rake::TestTask.new do |t|
-  t.libs << 'test'
+  t.libs << "test"
 end
 
 desc "Run tests"
-task :default => :test
+task default: :test

--- a/spambox.gemspec
+++ b/spambox.gemspec
@@ -1,15 +1,16 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |gem|
-  gem.name          = 'spambox'
-  gem.version       = '0.2'
-  gem.date          = '2015-12-04'
+  gem.name          = "spambox"
+  gem.version       = "0.3.2"
+  gem.date          = "2016-01-08"
   gem.authors       = ["Joshua Jansen"]
   gem.email         = ["joshuajansen88@gmail.com"]
-  gem.description   = %q{Spambox uses Formbox.es API to check for spam.}
-  gem.summary       = %q{Spambox is a gem that checks your objects for unsafe keywords and returns a spam score.}
+  gem.description   = "Spambox uses Formbox.es API to check for spam."
+  gem.summary       = "Spambox is a gem that checks your objects
+    for unsafe keywords and returns a spam score."
   gem.homepage      = "https://github.com/joshuajansen/spambox"
   gem.files         = ["lib/spambox.rb"]
-  gem.license       = 'MIT'
+  gem.license       = "MIT"
   gem.add_runtime_dependency "sanitize", "~> 4.0"
 end

--- a/test/support/entry_mock.rb
+++ b/test/support/entry_mock.rb
@@ -10,6 +10,6 @@ class EntryMock < ActiveRecord::Base
   end
 
   def self.column_names
-    ["name", "body"]
+    %w(name body)
   end
 end

--- a/test/test_spam_filter.rb
+++ b/test/test_spam_filter.rb
@@ -1,6 +1,6 @@
-require 'minitest/autorun'
-require 'spambox'
-require 'support/entry_mock'
+require "minitest/autorun"
+require "spambox"
+require "support/entry_mock"
 
 class TestSpambox < Minitest::Test
   def test_only_spam_words_is_100
@@ -12,11 +12,11 @@ class TestSpambox < Minitest::Test
   end
 
   def test_safe_string_with_html_allowed_is_0
-    assert_equal Spambox.new("<a href='#foo'>", { allow_html: true }).spam_score, 0
+    assert_equal Spambox.new("<a href='#foo'>", allow_html: true).spam_score, 0
   end
 
   def test_unsafe_string_with_html_allowed_is_100
-    assert_equal Spambox.new("<a href='#foo'>pharmacy</a>", { allow_html: true }).spam_score, 100
+    assert_equal Spambox.new("<a href='#foo'>pharmacy</a>", allow_html: true).spam_score, 100
   end
 
   def test_half_spam_words_is_50
@@ -30,5 +30,32 @@ class TestSpambox < Minitest::Test
   def test_active_record_object_for_spam
     object = EntryMock.new("Billion dollar Pharmacy", "Cheap banana pancakes")
     assert_equal Spambox.new(object).spam_score, 50
+  end
+
+  def test_line_breaks_should_pass_spambox
+    object = EntryMock.new(
+      "joshua@firmhouse.com",
+      "Hello, \r\n\r\nI like to get in contact!\r\n
+      Looking forward to hearing from you. \r\nBye, \r\n John"
+    )
+
+    assert_equal Spambox.new(object).spam_score, 0
+  end
+
+  def test_flatten_hash_values_returns_values_from_nested_hash
+    hash = {
+      form: {
+        name: "John",
+        email: "john@example.com",
+        body: "Hi!",
+        address: {
+          street: "Mainstreet 1"
+        }
+      }
+    }
+
+    flat_hash = Spambox.new(hash).send(:flatten_hash_values, hash)
+
+    assert_equal flat_hash, ["John", "john@example.com", "Hi!", "Mainstreet 1"]
   end
 end


### PR DESCRIPTION
Content with newlines from textareas (i.e. \n) got marked as spam because it got interpreted as HTML. This PR resolves that issue by leveraging active_support's `squish` method, which strips all whitespace characters before sanitizing.